### PR TITLE
Use strict equality in HAXCMS::testLogin

### DIFF
--- a/system/lib/HAXCMS.php
+++ b/system/lib/HAXCMS.php
@@ -123,13 +123,13 @@ class HAXCMS {
    * test the active user login based on session.
    */
   public function testLogin($adminFallback = FALSE) {
-    if ($this->user->name == $_SERVER['PHP_AUTH_USER'] && $this->user->password == $_SERVER['PHP_AUTH_PW']) {
+    if ($this->user->name === $_SERVER['PHP_AUTH_USER'] && $this->user->password === $_SERVER['PHP_AUTH_PW']) {
       return TRUE;
     }
     // if fallback is allowed, meaning the super admin then let them in
     // the default is to strictly test for the login in question
     // the fallback being allowable is useful for managed environments
-    else if ($adminFallback && $this->superUser->name == $_SERVER['PHP_AUTH_USER'] && $this->superUser->password == $_SERVER['PHP_AUTH_PW']) {
+    else if ($adminFallback && $this->superUser->name === $_SERVER['PHP_AUTH_USER'] && $this->superUser->password === $_SERVER['PHP_AUTH_PW']) {
       return TRUE;
     }
     return FALSE;


### PR DESCRIPTION
Currently `==` is used when testing login credentials, which means that logging in with no username and password authenticates successfully. `===` should be used wherever possible.

Replication steps: Try to login with no credentials, see success message.

Also 👋 Bryan