### PR TITLE
[NO MERGE] JWT rework start

### DIFF
--- a/system/lib/Operations.php
+++ b/system/lib/Operations.php
@@ -1797,4 +1797,18 @@ class Operations {
       );
     }
   }
+
+  public function accessToken() {
+    // check that we have a valid refresh token
+    $validRefresh  = $GLOBALS['HAXCMS']->validateRefreshToken();
+    // if we have a valid refresh token then issue a new access token
+    if ($validRefresh) {
+      return $GLOBALS['HAXCMS']->getJWT($validRefresh->user);
+    }
+    else {
+      header('Status: 403');
+      print 'Invalid refresh_token';
+      exit;
+    }
+  }
 }

--- a/system/lib/Request.php
+++ b/system/lib/Request.php
@@ -45,7 +45,7 @@ class Request {
      */
     public function execute($op, $params = array(), $rawParams = array()) {
       // we only skip JWT validation on edge cases
-      if (in_array($op, array('generateAppStore', 'listSites'))) {
+      if (in_array($op, array('generateAppStore', 'listSites', 'accessToken'))) {
         $this->validateJWT = FALSE;
       }
       if ($this->valid()) {

--- a/system/login.php
+++ b/system/login.php
@@ -18,6 +18,10 @@ if (isset($post->u) && isset($post->p)) {
   } else {
       header('Content-Type: application/json');
       header('Status: 200');
+      /**
+       * @todo need to configure domain and possibly path
+       */
+      setcookie('refresh_token', $HAXCMS->getRefreshToken(), $_expires = 0, $_path = '/', $_domain = '', $_secure = false, $_httponly = true);
       print json_encode($HAXCMS->getJWT());
       exit;
   }


### PR DESCRIPTION
added refresh_token cookie to /login.php.  Added system/request.php?op=accessToken endpoint. #431


This will set up an authorization workflow of:
- user makes request to `/login`
- request comes back with an access_token aka jwt and a refresh_token stored in a httponly cookie
- the front-end makes requests using the access_token in the headers
- access_token expires after 15 min
- front-end noticies 403 responses and makes a call to `system/request.php?op=accessToken` with a valid refresh_token
- a new access token comes back and we continue making 200 request and the user doesn't know what just happened


Front-end rework that needs to happen:
- [x] front-end needs to catch 403 errors
-- [ ] we need to differentiate between normal 403 errors and `access_token` expired errors. the reason is that we could have a valid login but be denied access to an endpoint.
- [x] Each catch should attempt to hit `/system/request.php?op=accessToken`.  The response is a new `access_token`.
- [x] If the request to `/system/request.php?op=accessToken` fails then we should redirect user to the login screen.

