### PR TITLE
[security] Disable Apache2 mod_status across PHP install scripts

### DIFF
--- a/scripts/install/ubuntu18.04.sh
+++ b/scripts/install/ubuntu18.04.sh
@@ -37,6 +37,7 @@ sudo a2dismod mpm_prefork
 sudo a2enmod mpm_event
 sudo a2enmod http2
 sudo a2enmod rewrite
+sudo a2dismod status
 # enable protocol support
 sudo echo "Protocols h2 http/1.1" > /etc/apache2/conf-available/http2.conf
 sudo a2enconf http2

--- a/scripts/install/ubuntu20.04.sh
+++ b/scripts/install/ubuntu20.04.sh
@@ -39,6 +39,7 @@ sudo a2enconf php7.4-fpm
 sudo a2dismod php7.4
 sudo a2dismod mpm_prefork
 sudo a2enmod mpm_event
+sudo a2dismod status
 # enable protocol support
 sudo echo "Protocols h2 http/1.1" > /etc/apache2/conf-available/http2.conf
 sudo a2enconf http2

--- a/scripts/install/ubuntu22.04.sh
+++ b/scripts/install/ubuntu22.04.sh
@@ -39,6 +39,7 @@ sudo a2enconf php8.1-fpm
 sudo a2dismod php8.1
 sudo a2dismod mpm_prefork
 sudo a2enmod mpm_event
+sudo a2dismod status
 # enable protocol support
 sudo echo "Protocols h2 http/1.1" > /etc/apache2/conf-available/http2.conf
 sudo a2enconf http2

--- a/scripts/install/ubuntu24.04.sh
+++ b/scripts/install/ubuntu24.04.sh
@@ -39,6 +39,7 @@ sudo a2enconf php8.3-fpm
 sudo a2dismod php8.3
 sudo a2dismod mpm_prefork
 sudo a2enmod mpm_event
+sudo a2dismod status
 # enable protocol support
 sudo echo "Protocols h2 http/1.1" > /etc/apache2/conf-available/http2.conf
 sudo a2enconf http2


### PR DESCRIPTION
## New Features
* Disables Apache2 `status` module for all HAXcms-PHP deployments
    * On several Linux distributions, the Apache2 package has its `status` module enabled by default
    * There's the potential to leak system data like: logs, users, URLs, and even local file paths

## Related Issue(s)
* https://github.com/haxtheweb/issues/issues/2627