### PR TITLE
Restore app-store site-token-only auth stance (fix regression)

### DIFF
--- a/system/backend/php/lib/siteRoutes/SiteRouteUtils.php
+++ b/system/backend/php/lib/siteRoutes/SiteRouteUtils.php
@@ -869,7 +869,8 @@ class SiteRouteUtils
      * Normalize an OpenAPI security config array into a policy string.
      * Mirrors Node normalizeSiteApiSecurityPolicy (app.js:1622):
      * - empty array or requirement with no keys => 'public'
-     * - requirement with siteTokenHeader => 'authenticated-site'
+     * - requirement with siteTokenHeader + bearerAuth => 'authenticated-site'
+     * - requirement with siteTokenHeader alone => 'site-token-only'
      * - requirement with userTokenHeader => 'authenticated-user' (precedence over bearer)
      * - requirement with bearerAuth => 'authenticated'
      * - default => 'public'
@@ -889,7 +890,17 @@ class SiteRouteUtils
                 return 'public';
             }
             if (array_key_exists('siteTokenHeader', $requirement)) {
-                return 'authenticated-site';
+                // siteTokenHeader paired with bearerAuth (in the same
+                // requirement) is 'authenticated-site' (bearer JWT + site
+                // token, e.g. provider-search, site API mutations).
+                // siteTokenHeader alone is 'site-token-only' — the site token
+                // is validated against the server-side active user by the
+                // handler (e.g. generateAppStore), no bearer JWT required.
+                // Mirrors Node normalizeSiteApiSecurityPolicy (app.js).
+                if (array_key_exists('bearerAuth', $requirement)) {
+                    return 'authenticated-site';
+                }
+                return 'site-token-only';
             }
             if (array_key_exists('userTokenHeader', $requirement)) {
                 $requiresUserToken = true;

--- a/system/backend/php/lib/systemRoutes/SystemApiSecurity.php
+++ b/system/backend/php/lib/systemRoutes/SystemApiSecurity.php
@@ -12,6 +12,18 @@ class SystemApiSecurity
                 'message' => '',
             );
         }
+        // 'site-token-only' routes (e.g. integrations/app-store) declare
+        // siteTokenHeader without bearerAuth. The router does not require a
+        // bearer JWT; the handler validates the X-HAXCMS-Site-Token against
+        // the server-side active user. This mirrors the original
+        // handler-validated behavior and Node's open-route + handler pattern.
+        if ($security === 'site-token-only') {
+            return array(
+                'allowed' => true,
+                'status' => 200,
+                'message' => '',
+            );
+        }
         // Resolve authenticated userName from Bearer (primary) or Basic (fallback).
         // Basic-auth fallback mirrors the NodeJS system route handler and shares
         // the login rate-limit counters (429 + Retry-After on brute-force lockout).


### PR DESCRIPTION
normalizeSecurityPolicy now distinguishes siteTokenHeader-only ('site-token-only') from bearerAuth+siteTokenHeader ('authenticated-site'), mirroring Node. The app-store GET declares siteTokenHeader alone, so it maps to 'site-token-only'.

SystemApiSecurity::validateSystemApiAccess treats 'site-token-only' as allowed at the router (no bearer JWT required); the handler (integrations.php -> Operations::generateAppStore) validates the X-HAXCMS-Site-Token against the server-side active user, as it did before the spec-driven conformance work.

Previously the spec-driven policy mapped siteTokenHeader to 'authenticated-site' unconditionally, which required a bearer JWT at the router (401 'Authentication required'). The front-end appStore fetch sends the site token but not a bearer JWT, so the call was rejected.

provider-search (bearerAuth+siteTokenHeader) stays 'authenticated-site' and is unaffected. No site-spec routes declare siteTokenHeader-only, so the site API is unaffected.

# [ISSUE XXXX](https://github.com/haxtheweb/issues/issues/XXXX)

## Description of Changes
*
*

## Before submitting this PR, I made sure I:
- [ ] Followed the coding conventions
- [ ] Added/updated tests for changes
- [ ] Verified accessibility (Lighthouse score, Screen-Reader)
- [ ] Updated documentation where necessary
- [ ] Checked cross-browser compatibility

## Ways to test
1. 
2.
3. 

## Notes
<!-- Any additional context, decisions, or follow-up work -->

## Console Output Screenshot